### PR TITLE
Configure Kangaroo Electron app to use community bootstrap server

### DIFF
--- a/kangaroo.config.ts
+++ b/kangaroo.config.ts
@@ -12,8 +12,8 @@ export default defineConfig({
   systray: true,
   passwordMode: 'no-password',
   networkSeed: 'alpha-test-2025',
-  bootstrapUrl: 'https://dev-test-bootstrap2.holochain.org/',
-  signalUrl: 'wss://dev-test-bootstrap2.holochain.org/',
+  bootstrapUrl: 'https://holostrap.elohim.host/',
+  signalUrl: 'wss://holostrap.elohim.host/',
   iceUrls: ['stun:stun.cloudflare.com:3478', 'stun:stun.l.google.com:19302'],
   bins: {
     holochain: {


### PR DESCRIPTION
## Summary
Configures the Kangaroo Electron app to use Matthew Dowell's community-hosted bootstrap server for peer discovery and signaling.

## Changes
- Updated `bootstrapUrl` from `https://dev-test-bootstrap2.holochain.org/` to `https://holostrap.elohim.host/`
- Updated `signalUrl` from `wss://dev-test-bootstrap2.holochain.org/` to `wss://holostrap.elohim.host/`

## Benefits
- Enables Electron app users to connect without setting up individual bootstrap servers
- Uses community-hosted infrastructure that's confirmed working
- Provides reliable peer discovery for alpha testing
- Maintains consistency with web app configuration (see companion PR in main repository)

## Testing
Bootstrap server endpoints have been verified as operational and responding correctly.

## Related
This complements the similar configuration changes made to the web version of the Requests & Offers hApp.