### PR TITLE
fix(unpack-pouch): migrate to unpackAndSaveWebhapp async API

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
     "@holochain/client": "^0.20.0",
-    "@holochain/hc-spin-rust-utils": "0.600.0",
+    "@holochain/hc-spin-rust-utils": "0.700.0-dev.0",
     "@matthme/electron-updater": "6.3.0-alpha.1",
     "@msgpack/msgpack": "^2.8.0",
     "adm-zip": "0.5.14",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "requests-and-offers.happenings-community.kangaroo-electron",
   "version": "0.4.0",
   "license": "CAL-1.0",
+  "homepage": "https://github.com/happenings-community/requests-and-offers",
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "yarn write:configs && yarn pouch:unpack && yarn create:icons && electron-vite dev",

--- a/scripts/unpack-pouch.js
+++ b/scripts/unpack-pouch.js
@@ -16,4 +16,7 @@ if (fs.existsSync(uiDir)) {
 }
 fs.mkdirSync(uiDir, { recursive: true });
 
-rustUtils.saveHappOrWebhapp(webhappPath, 'kangaroo', uiDir, resourcesDir);
+rustUtils.unpackAndSaveWebhapp(webhappPath, 'kangaroo', uiDir, resourcesDir).catch((err) => {
+  console.error('Failed to unpack webhapp:', err);
+  process.exit(1);
+});

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -130,7 +130,7 @@ export const createHappWindow = async (
   } else if (uiSource.type === 'path') {
     try {
       console.log('loading URL');
-      await happWindow.loadURL(`webhapp://webhappwindow/index.html`);
+      await happWindow.loadURL(`webhapp://webhappwindow/`);
       console.log('URL loaded');
     } catch (e) {
       console.error('[ERROR] Failed to fetch index.html');

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -42,9 +42,14 @@ export const createHappWindow = async (
       const relativeFilePath = path.join(...filePathComponents);
       const absoluteFilePath = path.join(uiSource.path, relativeFilePath);
 
-      const fallbackToIndexHtml = KANGAROO_CONFIG.fallbackToIndexHtml
-        ? !fs.existsSync(absoluteFilePath)
-        : false;
+      // When the URL is the root path (/), path.join("") resolves to "."
+      // which points to the build directory itself. fs.existsSync(directory)
+      // returns true, causing the fallback to be skipped and the directory
+      // fetched as a file — producing a 404 on initial load and reload of /.
+      const isRootPath = relativeFilePath === '.' || relativeFilePath === '';
+      const fallbackToIndexHtml =
+        isRootPath ||
+        (KANGAROO_CONFIG.fallbackToIndexHtml ? !fs.existsSync(absoluteFilePath) : false);
 
       if (!relativeFilePath.endsWith('index.html') && !fallbackToIndexHtml) {
         return net.fetch(url.pathToFileURL(absoluteFilePath).toString());


### PR DESCRIPTION
## Intent

`hc-spin-rust-utils` v0.700.0-dev.0 renamed the synchronous `saveHappOrWebhapp` to the async `unpackAndSaveWebhapp`. The build script `unpack-pouch.js` was calling the old name, which silently returned `undefined` and left `resources/ui/` empty in the AppImage. This caused the app to fail to launch.

## Changes

- **`scripts/unpack-pouch.js`**: Migrate from removed `saveHappOrWebhapp` (sync, old API) to `unpackAndSaveWebhapp` (async, returns `Promise<void>`). Added `.catch()` handler that exits with code 1 on failure so errors surface clearly.
- **`package.json`**: Pin `@holochain/hc-spin-rust-utils` to `0.700.0-dev.0` to match the installed version and prevent regression on fresh installs.
- **`package.json`**: Add `homepage` field required by the `deb` build target in electron-builder.

## How to test

1. Put a valid `.webhapp` in the `pouch/` directory
2. Run `yarn pouch:unpack` — `resources/ui/` should now be populated with HTML/JS/CSS files
3. Run `yarn build:linux` — both AppImage and deb should build without error
4. Launch the AppImage — the UI should load